### PR TITLE
[fix-early-null-keypath]

### DIFF
--- a/JSONValue/JSON.swift
+++ b/JSONValue/JSON.swift
@@ -163,6 +163,8 @@ public enum JSONValue: CustomStringConvertible {
                 default:
                     return self[index.keyPath]
                 }
+            case .null():
+                return .null()
             default:
                 return nil
             }
@@ -195,7 +197,8 @@ public enum JSONValue: CustomStringConvertible {
             let components = index.components(separatedBy: ".")
             if let result = self[components] {
                 return result
-            } else {
+            }
+            else {
                 return self[[index]]
             }
         }
@@ -216,11 +219,14 @@ public enum JSONValue: CustomStringConvertible {
             case .object(let obj):
                 if let next = obj[key] {
                     return next[Array(keys)]
-                } else {
+                }
+                else {
                     return nil
                 }
             case .array(let arr):
                 return .array(arr.flatMap { $0[index] })
+            case .null():
+                return .null()
             default:
                 return nil
             }
@@ -235,7 +241,8 @@ public enum JSONValue: CustomStringConvertible {
                 case .object(var obj):
                     if (newValue != nil) {
                         obj.updateValue(newValue!, forKey: key)
-                    } else {
+                    }
+                    else {
                         obj.removeValue(forKey: key)
                     }
                     self = .object(obj)

--- a/JSONValueTests/JSONValueTests.swift
+++ b/JSONValueTests/JSONValueTests.swift
@@ -45,6 +45,13 @@ class JSONValueTests: XCTestCase {
         XCTAssertEqual(jObj[1], JSONValue.string("yo"))
     }
     
+    func testEarlyNullReturnsNullWhenSubscriptingKeyPath() {
+        let dict = [ "derp" : NSNull() ]
+        let jObj = try! JSONValue(dict: dict)
+        
+        XCTAssertEqual(jObj["derp.blerp"], JSONValue.null())
+    }
+    
     // MARK: - Hashable
     
     func testFalseAndTrueHashesAreNotEqual() {


### PR DESCRIPTION
if null is returned in an early part of the keypath then return null