### PR TITLE
Only include *.swift files in podspec source_files

### DIFF
--- a/JSONValueRX.podspec
+++ b/JSONValueRX.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '8.0'
   s.requires_arc = true
 
-  s.source_files = 'Sources/**/*'
+  s.source_files = 'Sources/**/*.swift'
   s.resource_bundles = {
   }
 


### PR DESCRIPTION
When building with Xcode 10 an error is thrown regarding the inclusion of `Info.plist` in the `Compile Sources` phase:
```
error: Multiple commands produce '/Users/alexleffelman/Library/Developer/Xcode/DerivedData/Remind101-ekwpxciacyorzwchbahtvxxglwnj/Build/Products/Developer-iphonesimulator/JSONValueRX/JSONValueRX.framework/Info.plist':
1) Target 'JSONValueRX' (project 'Pods') has copy command from '/Users/alexleffelman/Documents/Code/r101-ios-teacher/Pods/JSONValueRX/Sources/Info.plist' to '/Users/alexleffelman/Library/Developer/Xcode/DerivedData/Remind101-ekwpxciacyorzwchbahtvxxglwnj/Build/Products/Developer-iphonesimulator/JSONValueRX/JSONValueRX.framework/Info.plist'
2) Target 'JSONValueRX' (project 'Pods') has process command with output '/Users/alexleffelman/Library/Developer/Xcode/DerivedData/Remind101-ekwpxciacyorzwchbahtvxxglwnj/Build/Products/Developer-iphonesimulator/JSONValueRX/JSONValueRX.framework/Info.plist'
```

This updates the podspec to only include swift files in the pod source files.

Will test from this new fork to verify that this does what I expect it to.